### PR TITLE
Add complementary color wheel utility page

### DIFF
--- a/color-wheel.html
+++ b/color-wheel.html
@@ -1,0 +1,207 @@
+<script src="js/templates.js"></script>
+<script>document.write(headerTemplate);</script>
+
+<main class="container py-4" id="color-wheel-app">
+  <header class="mb-4">
+    <h1 class="display-6 fw-semibold mb-2">Complementary Color Wheel</h1>
+    <p class="text-body-secondary mb-0">Explore a hue on the wheel, see its perfect opposite, and grab the surrounding split-complementary matches. Adjust saturation, lightness, and the offset to fine tune your palette.</p>
+  </header>
+
+  <div class="row g-4">
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h2 class="h5">Color Controls</h2>
+          <p class="text-body-secondary small">Type a HEX value or use the picker to jump anywhere on the wheel. Use the sliders to refine hue, saturation, lightness, and the adjacent offset.</p>
+
+          <div class="row g-3 align-items-end mt-3">
+            <div class="col-sm-8">
+              <label for="hex-input" class="form-label text-body-secondary mb-1">HEX Input</label>
+              <input type="text" id="hex-input" class="form-control form-control-lg" placeholder="#3498DB" autocomplete="off">
+            </div>
+            <div class="col-sm-4 text-sm-end">
+              <label for="hex-picker" class="form-label text-body-secondary mb-1">Color Picker</label>
+              <input type="color" id="hex-picker" class="form-control form-control-color form-control-lg" title="Pick a color">
+            </div>
+          </div>
+          <div id="hex-error" class="alert alert-warning py-2 px-3 mt-3 d-none" role="alert">
+            Enter a valid hex (#RGB or #RRGGBB)
+          </div>
+
+          <div class="mt-4">
+            <div class="mb-3">
+              <label for="hue-slider" class="form-label text-body-secondary">Hue <span class="badge text-bg-secondary ms-2" id="hue-value">0°</span></label>
+              <input type="range" class="form-range" min="0" max="360" id="hue-slider">
+            </div>
+            <div class="row g-3">
+              <div class="col-12 col-sm-4">
+                <label for="sat-slider" class="form-label text-body-secondary">Saturation</label>
+                <input type="range" class="form-range" min="0" max="100" id="sat-slider">
+              </div>
+              <div class="col-12 col-sm-4">
+                <label for="lig-slider" class="form-label text-body-secondary">Lightness</label>
+                <input type="range" class="form-range" min="0" max="100" id="lig-slider">
+              </div>
+              <div class="col-12 col-sm-4">
+                <label for="offset-slider" class="form-label text-body-secondary">Adjacent Offset <span class="badge text-bg-secondary ms-1" id="offset-value">30°</span></label>
+                <input type="range" class="form-range" min="5" max="60" step="1" id="offset-slider">
+                <p class="text-body-secondary small mb-0">Controls how far the split complements sit from the exact opposite.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <div class="d-flex align-items-center justify-content-between">
+            <h2 class="h5 mb-0">Swatches</h2>
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-all>Copy All HEX</button>
+          </div>
+
+          <div class="row g-3 mt-1">
+            <div class="col-sm-6" data-swatch="base">
+              <div class="swatch-panel border rounded-3 overflow-hidden">
+                <div class="swatch-header d-flex justify-content-between align-items-center px-3 py-2 border-bottom border-dark-subtle bg-body-tertiary">
+                  <span class="text-body-secondary small">Base</span>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="base">Copy</button>
+                </div>
+                <div class="swatch-chip text-center" data-swatch-chip="base">
+                  <div class="fw-semibold font-monospace" data-swatch-hex="base"></div>
+                  <div class="text-body-secondary small" data-swatch-sub="base"></div>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6" data-swatch="complement">
+              <div class="swatch-panel border rounded-3 overflow-hidden">
+                <div class="swatch-header d-flex justify-content-between align-items-center px-3 py-2 border-bottom border-dark-subtle bg-body-tertiary">
+                  <span class="text-body-secondary small">Opposite</span>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="complement">Copy</button>
+                </div>
+                <div class="swatch-chip text-center" data-swatch-chip="complement">
+                  <div class="fw-semibold font-monospace" data-swatch-hex="complement"></div>
+                  <div class="text-body-secondary small" data-swatch-sub="complement"></div>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6" data-swatch="splitA">
+              <div class="swatch-panel border rounded-3 overflow-hidden">
+                <div class="swatch-header d-flex justify-content-between align-items-center px-3 py-2 border-bottom border-dark-subtle bg-body-tertiary">
+                  <span class="text-body-secondary small">Adj −<span data-offset-legend></span>°</span>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="splitA">Copy</button>
+                </div>
+                <div class="swatch-chip text-center" data-swatch-chip="splitA">
+                  <div class="fw-semibold font-monospace" data-swatch-hex="splitA"></div>
+                  <div class="text-body-secondary small" data-swatch-sub="splitA"></div>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6" data-swatch="splitB">
+              <div class="swatch-panel border rounded-3 overflow-hidden">
+                <div class="swatch-header d-flex justify-content-between align-items-center px-3 py-2 border-bottom border-dark-subtle bg-body-tertiary">
+                  <span class="text-body-secondary small">Adj +<span data-offset-legend></span>°</span>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="splitB">Copy</button>
+                </div>
+                <div class="swatch-chip text-center" data-swatch-chip="splitB">
+                  <div class="fw-semibold font-monospace" data-swatch-hex="splitB"></div>
+                  <div class="text-body-secondary small" data-swatch-sub="splitB"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-7">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+            <h2 class="h5 mb-0">Color Wheel</h2>
+            <div class="d-flex flex-wrap gap-3 small text-body-secondary">
+              <div class="d-flex align-items-center gap-2">
+                <span class="legend-dot" data-legend="base"></span>
+                <span>Base</span>
+              </div>
+              <div class="d-flex align-items-center gap-2">
+                <span class="legend-dot" data-legend="complement"></span>
+                <span>Opposite</span>
+              </div>
+              <div class="d-flex align-items-center gap-2">
+                <span class="legend-dot hollow" data-legend="split"></span>
+                <span>Adjacents</span>
+              </div>
+            </div>
+          </div>
+          <p class="text-body-secondary small mt-2 mb-3">Click or drag on the wheel, use the Hue slider, or press ← / → (hold Shift for ±10°) to navigate.</p>
+
+          <div class="color-wheel mx-auto" id="color-wheel" role="slider" aria-label="Hue selector" aria-valuemin="0" aria-valuemax="360" aria-valuenow="0" tabindex="0">
+            <div class="color-wheel-ring"></div>
+            <div class="color-wheel-hole"></div>
+            <div class="wheel-marker" id="marker-base" title="Base"></div>
+            <div class="wheel-marker" id="marker-opposite" title="Opposite"></div>
+            <div class="wheel-marker hollow" id="marker-split-a" title="Adjacent −"></div>
+            <div class="wheel-marker hollow" id="marker-split-b" title="Adjacent +"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-5">
+      <div class="card shadow-sm h-100">
+        <div class="card-body d-flex flex-column">
+          <h2 class="h5">Opposite Suggestions</h2>
+          <p class="text-body-secondary small">We preserve the current saturation and lightness, rotate the hue 180° for the perfect complement, and straddle that opposite by the offset for the split complements.</p>
+
+          <div class="suggestion-list mt-3">
+            <div class="suggestion-row" data-row="base">
+              <div class="chip" data-row-chip="base"></div>
+              <div class="flex-grow-1">
+                <div class="text-body-secondary small">Base</div>
+                <div class="fw-semibold font-monospace" data-row-hex="base"></div>
+                <div class="text-body-secondary small" data-row-desc="base"></div>
+              </div>
+              <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="base">Copy</button>
+            </div>
+            <div class="suggestion-row" data-row="complement">
+              <div class="chip" data-row-chip="complement"></div>
+              <div class="flex-grow-1">
+                <div class="text-body-secondary small">Opposite (Complement)</div>
+                <div class="fw-semibold font-monospace" data-row-hex="complement"></div>
+                <div class="text-body-secondary small" data-row-desc="complement"></div>
+              </div>
+              <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="complement">Copy</button>
+            </div>
+            <div class="suggestion-row" data-row="splitA">
+              <div class="chip" data-row-chip="splitA"></div>
+              <div class="flex-grow-1">
+                <div class="text-body-secondary small">Adjacent −<span data-offset-legend></span>°</div>
+                <div class="fw-semibold font-monospace" data-row-hex="splitA"></div>
+                <div class="text-body-secondary small" data-row-desc="splitA"></div>
+              </div>
+              <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="splitA">Copy</button>
+            </div>
+            <div class="suggestion-row" data-row="splitB">
+              <div class="chip" data-row-chip="splitB"></div>
+              <div class="flex-grow-1">
+                <div class="text-body-secondary small">Adjacent +<span data-offset-legend></span>°</div>
+                <div class="fw-semibold font-monospace" data-row-hex="splitB"></div>
+                <div class="text-body-secondary small" data-row-desc="splitB"></div>
+              </div>
+              <button type="button" class="btn btn-outline-secondary btn-sm" data-copy-target="splitB">Copy</button>
+            </div>
+          </div>
+
+          <div class="mt-4 pt-3 border-top border-dark-subtle text-body-secondary small">
+            <strong class="text-light">Pro tip:</strong> Tighten the offset for analogous accents or widen it for punchier contrasts.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script src="js/color-wheel.js"></script>
+<script>document.write(footerTemplate);</script>

--- a/js/color-wheel.js
+++ b/js/color-wheel.js
@@ -1,0 +1,524 @@
+(function () {
+  const headerLink = document.querySelector('a[href="color-wheel.html"]');
+  if (headerLink) {
+    headerLink.classList.add('active');
+    headerLink.setAttribute('aria-current', 'page');
+  }
+
+  const state = {
+    displayHex: '#3498DB',
+    hue: 0,
+    sat: 0,
+    lig: 0,
+    adjOffset: 30,
+    error: ''
+  };
+
+  const elements = {};
+  const copyTimers = new Map();
+
+  const hexMap = {
+    base: () => state.baseHex,
+    complement: () => state.complementHex,
+    splitA: () => state.splitHexA,
+    splitB: () => state.splitHexB
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    elements.hexInput = document.getElementById('hex-input');
+    elements.hexPicker = document.getElementById('hex-picker');
+    elements.hexError = document.getElementById('hex-error');
+    elements.hueSlider = document.getElementById('hue-slider');
+    elements.satSlider = document.getElementById('sat-slider');
+    elements.ligSlider = document.getElementById('lig-slider');
+    elements.offsetSlider = document.getElementById('offset-slider');
+    elements.hueValue = document.getElementById('hue-value');
+    elements.offsetValue = document.getElementById('offset-value');
+    elements.copyAll = document.querySelector('[data-copy-all]');
+    elements.wheel = document.getElementById('color-wheel');
+    elements.markers = {
+      base: document.getElementById('marker-base'),
+      complement: document.getElementById('marker-opposite'),
+      splitA: document.getElementById('marker-split-a'),
+      splitB: document.getElementById('marker-split-b')
+    };
+    elements.legends = {
+      base: document.querySelector('[data-legend="base"]'),
+      complement: document.querySelector('[data-legend="complement"]'),
+      split: document.querySelector('[data-legend="split"]')
+    };
+    elements.offsetLegends = Array.from(document.querySelectorAll('[data-offset-legend]'));
+
+    elements.swatches = {
+      base: getSwatchRefs('base'),
+      complement: getSwatchRefs('complement'),
+      splitA: getSwatchRefs('splitA'),
+      splitB: getSwatchRefs('splitB')
+    };
+
+    elements.rows = {
+      base: getRowRefs('base'),
+      complement: getRowRefs('complement'),
+      splitA: getRowRefs('splitA'),
+      splitB: getRowRefs('splitB')
+    };
+
+    elements.copyButtons = Array.from(document.querySelectorAll('[data-copy-target]'));
+
+    attachListeners();
+    initialiseState('#3498DB');
+    render();
+  });
+
+  function getSwatchRefs(key) {
+    return {
+      chip: document.querySelector(`[data-swatch-chip="${key}"]`),
+      hex: document.querySelector(`[data-swatch-hex="${key}"]`),
+      sub: document.querySelector(`[data-swatch-sub="${key}"]`)
+    };
+  }
+
+  function getRowRefs(key) {
+    return {
+      chip: document.querySelector(`[data-row-chip="${key}"]`),
+      hex: document.querySelector(`[data-row-hex="${key}"]`),
+      desc: document.querySelector(`[data-row-desc="${key}"]`)
+    };
+  }
+
+  function attachListeners() {
+    if (!elements.hexInput) return;
+
+    elements.hexInput.addEventListener('input', (event) => {
+      const value = event.target.value;
+      const normalized = hexNormalize(value);
+      if (normalized) {
+        applyHex(normalized);
+      } else {
+        state.displayHex = value;
+        state.error = value.trim() ? 'Enter a valid hex (#RGB or #RRGGBB)' : '';
+        render();
+      }
+    });
+
+    elements.hexPicker.addEventListener('input', (event) => {
+      const value = event.target.value;
+      if (hexNormalize(value)) {
+        applyHex(value.toUpperCase());
+      }
+    });
+
+    elements.hueSlider.addEventListener('input', (event) => {
+      state.hue = parseInt(event.target.value, 10);
+      syncDerivedColors();
+      state.displayHex = state.baseHex;
+      state.error = '';
+      render();
+    });
+
+    elements.satSlider.addEventListener('input', (event) => {
+      state.sat = parseInt(event.target.value, 10);
+      syncDerivedColors();
+      state.displayHex = state.baseHex;
+      state.error = '';
+      render();
+    });
+
+    elements.ligSlider.addEventListener('input', (event) => {
+      state.lig = parseInt(event.target.value, 10);
+      syncDerivedColors();
+      state.displayHex = state.baseHex;
+      state.error = '';
+      render();
+    });
+
+    elements.offsetSlider.addEventListener('input', (event) => {
+      state.adjOffset = parseInt(event.target.value, 10);
+      syncDerivedColors();
+      render();
+    });
+
+    elements.copyAll.addEventListener('click', async () => {
+      const text = [
+        `Base: ${state.baseHex}`,
+        `Opposite (Complement): ${state.complementHex}`,
+        `Adjacent to Opposite A (-${state.adjOffset}°): ${state.splitHexA}`,
+        `Adjacent to Opposite B (+${state.adjOffset}°): ${state.splitHexB}`
+      ].join('\n');
+      await copyToClipboard(elements.copyAll, text);
+    });
+
+    elements.copyButtons.forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const getter = hexMap[btn.dataset.copyTarget];
+        if (!getter) return;
+        await copyToClipboard(btn, getter());
+      });
+    });
+
+    setupWheel();
+
+    window.addEventListener('keydown', (event) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+      if (event.target && ['INPUT', 'TEXTAREA'].includes(event.target.tagName)) {
+        return;
+      }
+      event.preventDefault();
+      const delta = event.shiftKey ? 10 : 1;
+      if (event.key === 'ArrowLeft') {
+        state.hue = (state.hue + 360 - delta) % 360;
+      } else {
+        state.hue = (state.hue + delta) % 360;
+      }
+      syncDerivedColors();
+      state.displayHex = state.baseHex;
+      render();
+    });
+  }
+
+  function setupWheel() {
+    if (!elements.wheel) return;
+    let dragging = false;
+    let pointerId = null;
+
+    const handlePointer = (event) => {
+      const rect = elements.wheel.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const newHue = Math.round(pointToHue(event.clientX, event.clientY, cx, cy));
+      state.hue = ((newHue % 360) + 360) % 360;
+      syncDerivedColors();
+      state.displayHex = state.baseHex;
+      render();
+    };
+
+    elements.wheel.addEventListener('pointerdown', (event) => {
+      event.preventDefault();
+      dragging = true;
+      pointerId = event.pointerId;
+      elements.wheel.setPointerCapture(pointerId);
+      handlePointer(event);
+    });
+
+    elements.wheel.addEventListener('pointermove', (event) => {
+      if (!dragging) return;
+      handlePointer(event);
+    });
+
+    const stopDragging = (event) => {
+      if (!dragging) return;
+      dragging = false;
+      if (pointerId !== null) {
+        try {
+          elements.wheel.releasePointerCapture(pointerId);
+        } catch (err) {
+          // ignore if already released
+        }
+        pointerId = null;
+      }
+    };
+
+    elements.wheel.addEventListener('pointerup', stopDragging);
+    elements.wheel.addEventListener('pointercancel', stopDragging);
+  }
+
+  function initialiseState(initialHex) {
+    applyHex(initialHex);
+  }
+
+  function applyHex(hex) {
+    const rgb = hexToRgb(hex);
+    if (!rgb) {
+      state.error = 'Enter a valid hex (#RGB or #RRGGBB)';
+      render();
+      return;
+    }
+    const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+    state.hue = hsl.h;
+    state.sat = hsl.s;
+    state.lig = hsl.l;
+    state.displayHex = hex.toUpperCase();
+    state.error = '';
+    syncDerivedColors();
+    render();
+  }
+
+  function syncDerivedColors() {
+    state.baseHex = hslToHex(state.hue, state.sat, state.lig);
+    const complementHue = (state.hue + 180) % 360;
+    const splitHueA = (complementHue - state.adjOffset + 360) % 360;
+    const splitHueB = (complementHue + state.adjOffset) % 360;
+
+    state.complementHue = complementHue;
+    state.splitHueA = splitHueA;
+    state.splitHueB = splitHueB;
+    state.complementHex = hslToHex(complementHue, state.sat, state.lig);
+    state.splitHexA = hslToHex(splitHueA, state.sat, state.lig);
+    state.splitHexB = hslToHex(splitHueB, state.sat, state.lig);
+    state.displayHex = state.baseHex;
+  }
+
+  function render() {
+    if (!elements.hexInput) return;
+    elements.hexInput.value = state.displayHex;
+    elements.hexPicker.value = state.baseHex || '#000000';
+
+    if (state.error) {
+      elements.hexError.classList.remove('d-none');
+      elements.hexError.textContent = state.error;
+    } else {
+      elements.hexError.classList.add('d-none');
+    }
+
+    elements.hueSlider.value = state.hue;
+    elements.satSlider.value = state.sat;
+    elements.ligSlider.value = state.lig;
+    elements.offsetSlider.value = state.adjOffset;
+
+    elements.hueValue.textContent = `${state.hue}°`;
+    elements.offsetValue.textContent = `${state.adjOffset}°`;
+    elements.offsetLegends.forEach((el) => {
+      el.textContent = state.adjOffset;
+    });
+
+    updateSwatch('base', state.baseHex, `HSL ${state.hue}°, ${state.sat}%, ${state.lig}%`);
+    updateSwatch('complement', state.complementHex, `Hue ${state.complementHue}°`);
+    updateSwatch('splitA', state.splitHexA, `Hue ${state.splitHueA}°`);
+    updateSwatch('splitB', state.splitHexB, `Hue ${state.splitHueB}°`);
+
+    updateRow('base', state.baseHex, `HSL ${state.hue}°, ${state.sat}%, ${state.lig}%`);
+    updateRow('complement', state.complementHex, `Hue ${state.complementHue}°`);
+    updateRow('splitA', state.splitHexA, `Hue ${state.splitHueA}°`);
+    updateRow('splitB', state.splitHexB, `Hue ${state.splitHueB}°`);
+
+    updateLegends();
+    updateWheel();
+    updateCopyButtons();
+  }
+
+  function updateSwatch(key, hex, subtitle) {
+    const swatch = elements.swatches[key];
+    if (!swatch || !hex) return;
+    const textColor = textColorOn(hex);
+    swatch.hex.textContent = hex;
+    swatch.sub.textContent = subtitle;
+    swatch.chip.style.backgroundColor = hex;
+    swatch.chip.style.color = textColor;
+  }
+
+  function updateRow(key, hex, desc) {
+    const row = elements.rows[key];
+    if (!row || !hex) return;
+    row.hex.textContent = hex;
+    row.desc.textContent = desc;
+    row.chip.style.backgroundColor = hex;
+  }
+
+  function updateLegends() {
+    if (elements.legends.base) {
+      elements.legends.base.style.backgroundColor = state.baseHex;
+      elements.legends.base.style.borderColor = state.baseHex;
+    }
+    if (elements.legends.complement) {
+      elements.legends.complement.style.backgroundColor = state.complementHex;
+      elements.legends.complement.style.borderColor = state.complementHex;
+    }
+    if (elements.legends.split) {
+      elements.legends.split.style.borderColor = state.baseHex;
+    }
+  }
+
+  function updateWheel() {
+    if (!elements.wheel) return;
+    elements.wheel.setAttribute('aria-valuenow', String(state.hue));
+    const size = elements.wheel.offsetWidth || 0;
+    const center = size / 2;
+    const innerRadius = size * 0.29;
+    const outerRadius = Math.max(center - 6, innerRadius + 10);
+    const markerRadius = (outerRadius + innerRadius) / 2;
+
+    setMarker(elements.markers.base, hueToPoint(state.hue, center, center, markerRadius), state.baseHex, false);
+    setMarker(elements.markers.complement, hueToPoint(state.complementHue, center, center, markerRadius), state.complementHex, false);
+    setMarker(elements.markers.splitA, hueToPoint(state.splitHueA, center, center, markerRadius), state.splitHexA, true);
+    setMarker(elements.markers.splitB, hueToPoint(state.splitHueB, center, center, markerRadius), state.splitHexB, true);
+  }
+
+  function setMarker(marker, point, color, hollow) {
+    if (!marker || !point) return;
+    marker.style.left = `${point.x}px`;
+    marker.style.top = `${point.y}px`;
+    marker.style.borderColor = color;
+    if (hollow) {
+      marker.style.backgroundColor = 'transparent';
+      marker.style.boxShadow = 'none';
+    } else {
+      marker.style.backgroundColor = color;
+      marker.style.boxShadow = '0 0 0 3px rgba(0,0,0,0.35)';
+    }
+  }
+
+  function updateCopyButtons() {
+    elements.copyButtons.forEach((btn) => {
+      const getter = hexMap[btn.dataset.copyTarget];
+      if (!getter) return;
+      btn.dataset.hexValue = getter();
+    });
+  }
+
+  async function copyToClipboard(button, text) {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      flashCopied(button);
+    } catch (err) {
+      console.error('Clipboard write failed', err);
+    }
+  }
+
+  function flashCopied(button) {
+    if (!button) return;
+    const original = button.dataset.originalText || button.textContent;
+    button.dataset.originalText = original;
+    button.textContent = 'Copied!';
+    button.disabled = true;
+    const timeout = setTimeout(() => {
+      button.textContent = button.dataset.originalText;
+      button.disabled = false;
+    }, 1200);
+    if (copyTimers.has(button)) {
+      clearTimeout(copyTimers.get(button));
+    }
+    copyTimers.set(button, timeout);
+  }
+
+  function clamp(n, min, max) {
+    return Math.min(max, Math.max(min, n));
+  }
+
+  function pad2(n) {
+    const s = n.toString(16);
+    return s.length === 1 ? `0${s}` : s;
+  }
+
+  function hexNormalize(hex) {
+    if (!hex) return null;
+    const cleaned = hex.trim().replace(/[^0-9a-fA-F]/g, '');
+    if (cleaned.length === 3) {
+      return `#${cleaned.split('').map((c) => c + c).join('')}`.toUpperCase();
+    }
+    if (cleaned.length === 6) {
+      return `#${cleaned}`.toUpperCase();
+    }
+    return null;
+  }
+
+  function hexToRgb(hex) {
+    const normalized = hexNormalize(hex);
+    if (!normalized) return null;
+    const r = parseInt(normalized.slice(1, 3), 16);
+    const g = parseInt(normalized.slice(3, 5), 16);
+    const b = parseInt(normalized.slice(5, 7), 16);
+    return { r, g, b };
+  }
+
+  function rgbToHsl(r, g, b) {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h;
+    let s;
+    const l = (max + min) / 2;
+
+    if (max === min) {
+      h = s = 0;
+    } else {
+      const d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max - min);
+      switch (max) {
+        case r:
+          h = (g - b) / d + (g < b ? 6 : 0);
+          break;
+        case g:
+          h = (b - r) / d + 2;
+          break;
+        default:
+          h = (r - g) / d + 4;
+          break;
+      }
+      h /= 6;
+    }
+
+    return {
+      h: Math.round(h * 360),
+      s: Math.round(s * 100),
+      l: Math.round(l * 100)
+    };
+  }
+
+  function hslToRgb(h, s, l) {
+    h = ((h % 360) + 360) % 360;
+    s = clamp(s, 0, 100) / 100;
+    l = clamp(l, 0, 100) / 100;
+
+    let r;
+    let g;
+    let b;
+
+    if (s === 0) {
+      r = g = b = l;
+    } else {
+      const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+      const p = 2 * l - q;
+      const hk = h / 360;
+      r = hue2rgb(p, q, hk + 1 / 3);
+      g = hue2rgb(p, q, hk);
+      b = hue2rgb(p, q, hk - 1 / 3);
+    }
+
+    return {
+      r: Math.round(r * 255),
+      g: Math.round(g * 255),
+      b: Math.round(b * 255)
+    };
+  }
+
+  function hue2rgb(p, q, t) {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  }
+
+  function hslToHex(h, s, l) {
+    const { r, g, b } = hslToRgb(h, s, l);
+    return `#${pad2(r)}${pad2(g)}${pad2(b)}`.toUpperCase();
+  }
+
+  function textColorOn(hex) {
+    const rgb = hexToRgb(hex);
+    if (!rgb) return '#000000';
+    const srgb = [rgb.r, rgb.g, rgb.b].map((value) => {
+      const c = value / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    });
+    const L = 0.2126 * srgb[0] + 0.7152 * srgb[1] + 0.0722 * srgb[2];
+    return L > 0.53 ? '#111111' : '#FFFFFF';
+  }
+
+  function hueToPoint(h, cx, cy, r) {
+    const rad = ((h - 90) * Math.PI) / 180;
+    return {
+      x: cx + r * Math.cos(rad),
+      y: cy + r * Math.sin(rad)
+    };
+  }
+
+  function pointToHue(x, y, cx, cy) {
+    const angle = Math.atan2(y - cy, x - cx) * (180 / Math.PI);
+    return (angle + 90 + 360) % 360;
+  }
+})();

--- a/js/templates.js
+++ b/js/templates.js
@@ -43,6 +43,9 @@ const headerTemplate = `
           <a class="nav-link" href="prompt_builder.html">Prompt Builder</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="color-wheel.html">Color Wheel</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="feature-request.html">Feature Request</a>
         </li>
       </ul>

--- a/style.css
+++ b/style.css
@@ -100,3 +100,127 @@ textarea {
   color: #fff;
   background-color: #343a40;
 }
+
+/* Color wheel page */
+#color-wheel-app .card {
+  background-color: rgba(33, 37, 41, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #f8f9fa;
+}
+
+#color-wheel-app .card .text-body-secondary {
+  color: rgba(248, 249, 250, 0.65) !important;
+}
+
+#color-wheel-app .swatch-panel {
+  background: rgba(33, 37, 41, 0.6);
+}
+
+#color-wheel-app .swatch-chip {
+  min-height: 7rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 1.25rem;
+}
+
+#color-wheel-app .swatch-header {
+  background: rgba(33, 37, 41, 0.75) !important;
+}
+
+.legend-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  display: inline-block;
+}
+
+.legend-dot.hollow {
+  background: transparent !important;
+}
+
+.color-wheel {
+  --color-wheel-size: 22rem;
+  position: relative;
+  width: var(--color-wheel-size);
+  height: var(--color-wheel-size);
+  max-width: 100%;
+  border-radius: 50%;
+  outline: none;
+}
+
+.color-wheel-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    #ff0000,
+    #ffff00,
+    #00ff00,
+    #00ffff,
+    #0000ff,
+    #ff00ff,
+    #ff0000
+  );
+}
+
+.color-wheel-hole {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(var(--color-wheel-size) * 0.58);
+  height: calc(var(--color-wheel-size) * 0.58);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: rgba(33, 37, 41, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.wheel-marker {
+  position: absolute;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 3px solid #fff;
+  transform: translate(-50%, -50%);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.wheel-marker.hollow {
+  background: transparent;
+  box-shadow: none;
+}
+
+.suggestion-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.suggestion-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  background: rgba(33, 37, 41, 0.5);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.suggestion-row .chip {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #0d6efd;
+}
+
+@media (max-width: 576px) {
+  .color-wheel {
+    --color-wheel-size: min(18rem, 80vw);
+  }
+}


### PR DESCRIPTION
## Summary
- add a complementary color wheel page with interactive controls for hue, saturation, lightness, and split complements
- style the new page to match the existing dark Bootstrap theme
- expose the new tool in the global navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68facee825c8833288be0a38042b49b6